### PR TITLE
fixed map size in show

### DIFF
--- a/app/assets/stylesheets/layouts/_map.scss
+++ b/app/assets/stylesheets/layouts/_map.scss
@@ -26,8 +26,16 @@
 }
 
 #map {
+
+}
+
+.map-index {
   margin-top: 9px;
+  top: 0 !important;
   height: 100vh;
   position: sticky !important;
-  top: 0 !important;
+}
+
+.map-show {
+  height: 50vh !important;
 }

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -14,6 +14,6 @@
     <% end %>
   </div>
   <div class="index-map padding-right-none">
-    <%= render "shared/map" %>
+    <div id="map" class="map-index" data-markers="<%= @markers.to_json %>"></div>
   </div>
 </div>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -44,7 +44,7 @@
       </div>
     </div>
     <div class="row">
-      <%= render "shared/map" %>
+      <div id="map" class="map-show" data-markers="<%= @markers.to_json %>"></div>
     </div>
   </div> <!-- close wrapper -->
 </div> <!-- close container -->

--- a/app/views/shared/_map.html.erb
+++ b/app/views/shared/_map.html.erb
@@ -1,1 +1,1 @@
-<div id="map" data-markers="<%= @markers.to_json %>"></div>
+<div id="map" class="map-index" data-markers="<%= @markers.to_json %>"></div>


### PR DESCRIPTION
set map height in show to 50%vh.

Note: because the map height was set in an 'id', i have removed the css from the 'id' and placed it into 2 classes - 1 for show, the other for index.  Therefore the shared map render is now obsolete as the 2 maps are each unique.
Style did not work on a parent div (which would have been preferable), so i had to change the style of the actual map div, hence no more 'map render'.